### PR TITLE
[codex] Add conversation trigger icon

### DIFF
--- a/src/components/ConversationModal.tsx
+++ b/src/components/ConversationModal.tsx
@@ -1,5 +1,5 @@
 import * as Dialog from '@radix-ui/react-dialog'
-import { X } from 'lucide-react'
+import { MessageCircle, X } from 'lucide-react'
 
 type ConversationMessage = {
   role: 'user' | 'assistant'
@@ -21,7 +21,15 @@ export default function ConversationModal({
 }: ConversationModalProps) {
   return (
     <Dialog.Root>
-      <Dialog.Trigger className="conversation-trigger">{trigger}</Dialog.Trigger>
+      <Dialog.Trigger className="conversation-trigger">
+        <MessageCircle
+          aria-hidden="true"
+          className="conversation-trigger-icon"
+          size={15}
+          strokeWidth={1.8}
+        />
+        <span>{trigger}</span>
+      </Dialog.Trigger>
       <Dialog.Portal>
         <Dialog.Overlay className="conversation-overlay" />
         <Dialog.Content className="conversation-content">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -339,6 +339,10 @@ article img {
 }
 
 .conversation-trigger {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.3em;
+  vertical-align: baseline;
   color: inherit;
   text-decoration: underline;
   text-underline-offset: 2px;
@@ -346,6 +350,13 @@ article img {
   border: 0;
   padding: 0;
   font: inherit;
+  cursor: pointer;
+}
+
+.conversation-trigger-icon {
+  position: relative;
+  top: 0.12em;
+  flex: 0 0 auto;
 }
 
 .conversation-trigger:hover {


### PR DESCRIPTION
## Summary
- Add a Lucide chat bubble icon before conversation modal triggers
- Keep the trigger styled as inline prose with stable spacing and hover behavior

## Validation
- npm run build

## Notes
- Left the pre-existing local change in `src/pages/[slug].astro` unstaged and out of this PR.